### PR TITLE
Update styles.scss

### DIFF
--- a/repris2025/src/styles.scss
+++ b/repris2025/src/styles.scss
@@ -472,18 +472,33 @@ section {
     grid-template-columns: repeat(3, 1fr);
     justify-content: center;
     align-items: stretch;
+
+    .schedule-table-item {
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   @media (min-width: 620px) and (max-width: 999px) {
     grid-template-columns: repeat(2, 1fr);
     justify-content: center;
     align-items: stretch;
+    
+    .schedule-table-item {
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   @media (max-width: 619px) {
     grid-template-columns: 1fr;
     justify-content: center;
     align-items: stretch;
+
+    .schedule-table-item {
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   .menu-list.menu-list-vertical {


### PR DESCRIPTION
This pull request introduces styling updates to ensure consistent horizontal centering of `.schedule-table-item` elements across different screen sizes.

Styling updates for responsive design:

* [`repris2025/src/styles.scss`](diffhunk://#diff-7d9ed8218ec38affa63652c4a344856145d57acba4b7daf92ffce21c6959bfcaR475-R501): Added `margin-left: auto;` and `margin-right: auto;` to `.schedule-table-item` within the `section` element for all screen size breakpoints, ensuring the items are horizontally centered.